### PR TITLE
Fix post-build event command

### DIFF
--- a/src/WebCompiler/WebCompiler.csproj
+++ b/src/WebCompiler/WebCompiler.csproj
@@ -108,7 +108,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>nuget pack msbuild\BuildWebCompiler.nuspec</PostBuildEvent>
+    <PostBuildEvent>$(SolutionDir)packages\NuGet.CommandLine.2.8.5\tools\nuget.exe pack .\msbuild\BuildWebCompiler.nuspec</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/WebCompiler/packages.config
+++ b/src/WebCompiler/packages.config
@@ -1,8 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AjaxMin" version="5.14.5506.26202" targetFramework="net45" />
-  <package id="CoffeeSharp" version="0.6" targetFramework="net45" />
-  <package id="dotless" version="1.5.0" targetFramework="net45" />
-  <package id="libsassnet" version="3.2.4" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+  <package id="AjaxMin" version="5.14.5506.26202" targetFramework="net45" userInstalled="true" />
+  <package id="CoffeeSharp" version="0.6" targetFramework="net45" userInstalled="true" />
+  <package id="dotless" version="1.5.0" targetFramework="net45" userInstalled="true" />
+  <package id="libsassnet" version="3.2.4" targetFramework="net45" userInstalled="true" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" userInstalled="true" />
+  <package id="NuGet.CommandLine" version="2.8.5" targetFramework="net45" userInstalled="true" />
 </packages>


### PR DESCRIPTION
The project stopped building for me, probably because I don't have Nuget.exe in a path variable. With the NuGet.CommandLine package, the Nuget.exe will always be available for the post-build event command.