### PR TITLE
GitIgnore: Add NCrunch files and folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ x64/
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*
 
+# NCrunch
+*.ncrunchsolution
+*.ncrunchproject
+_NCrunch_WebCompiler


### PR DESCRIPTION
NCrunch is the way I have found to adhere to unit testing and TDD, but it's a little bit annoying to avoid including NCrunch's files on every commit.  