### PR TITLE
Fix boolean option flag handling in Less and CoffeeScript #25

### DIFF
--- a/src/WebCompiler/Compile/CoffeeScriptOptions.cs
+++ b/src/WebCompiler/Compile/CoffeeScriptOptions.cs
@@ -2,10 +2,12 @@
 {
     class CoffeeScriptOptions : BaseOptions
     {
-        public CoffeeScriptOptions(Config config)
+		private const string trueStr = "true";
+
+		public CoffeeScriptOptions(Config config)
         {
-            Bare = GetValue(config, "bare") == "true";
-            Globals = GetValue(config, "globals") == "true";
+            Bare = GetValue(config, "bare").ToLowerInvariant() == trueStr;
+            Globals = GetValue(config, "globals").ToLowerInvariant() == trueStr;
         }
 
         public bool Bare { get; set; }

--- a/src/WebCompiler/Compile/LessOptions.cs
+++ b/src/WebCompiler/Compile/LessOptions.cs
@@ -4,12 +4,14 @@ namespace WebCompiler
 {
     class LessOptions : BaseOptions
     {
+		private const string trueStr = "true";
+
         public LessOptions(Config config)
         {
-            StrictMath = GetValue(config, "strictMath") == "true";
-            KeepFirstSpecialComment = GetValue(config, "keepFirstSpecialComment") == "true";
-            DisableVariableRedefines = GetValue(config, "disableVariableRedefines") == "true";
-            DisableColorCompression = GetValue(config, "disableColorCompression") == "true";
+            StrictMath = GetValue(config, "strictMath").ToLowerInvariant() == trueStr;
+            KeepFirstSpecialComment = GetValue(config, "keepFirstSpecialComment").ToLowerInvariant() == trueStr;
+            DisableVariableRedefines = GetValue(config, "disableVariableRedefines").ToLowerInvariant() == trueStr;
+            DisableColorCompression = GetValue(config, "disableColorCompression").ToLowerInvariant() == trueStr;
         }
 
         public bool StrictMath { get; set; }

--- a/src/WebCompilerVsix/JSON/compilerconfig-schema.json
+++ b/src/WebCompilerVsix/JSON/compilerconfig-schema.json
@@ -48,7 +48,7 @@
 				},
 				"options": {
 					"properties": {
-						"disableColorcCompression": {
+						"disableColorCompression": {
 							"description": "LESS only. Disable hexadecimal color compression.",
 							"type": "boolean"
 						},


### PR DESCRIPTION
Here's a quick fix. I wish I had more time to get my hands dirty on this, but this should at least fix the issue. The problem was that `true.ToString()` evaluates to "True". This issue will likely come up again until a more type safe solution for handling the options is implemented.

I also fixed a Less configuration misspelling in the schema file to match what the code will be checking for.