### PR TITLE
Implement folder support.

### DIFF
--- a/src/WebCompiler/Config/ConfigHandler.cs
+++ b/src/WebCompiler/Config/ConfigHandler.cs
@@ -18,7 +18,7 @@ namespace WebCompiler
         /// <param name="config">The compiler config object to add to the configration file.</param>
         public void AddConfig(string fileName, Config config)
         {
-            IEnumerable<Config> existing = GetConfigs(fileName);
+            IEnumerable<Config> existing = GetVerbatimConfigs(fileName);
             List<Config> configs = new List<Config>();
             configs.AddRange(existing);
             configs.Add(config);
@@ -39,7 +39,7 @@ namespace WebCompiler
         /// </summary>
         public void RemoveConfig(Config configToRemove)
         {
-            IEnumerable<Config> configs = GetConfigs(configToRemove.FileName);
+            IEnumerable<Config> configs = GetVerbatimConfigs(configToRemove.FileName);
             List<Config> newConfigs = new List<Config>();
 
             if (configs.Contains(configToRemove))
@@ -95,6 +95,16 @@ namespace WebCompiler
         /// <param name="fileName">A relative or absolute file path to the configuration file.</param>
         /// <returns>A list of Config objects.</returns>
         public static IEnumerable<Config> GetConfigs(string fileName)
+        {
+            IEnumerable<Config> configs = GetVerbatimConfigs(fileName);
+
+            if (configs != null && configs.Any())
+                configs = configs.SelectMany(c => c.ExpandConfig()).Distinct().ToList();
+
+            return configs;
+        }
+
+        private static IEnumerable<Config> GetVerbatimConfigs(string fileName)
         {
             FileInfo file = new FileInfo(fileName);
 

--- a/src/WebCompilerTest/Config/ConfigHandlerTest.cs
+++ b/src/WebCompilerTest/Config/ConfigHandlerTest.cs
@@ -35,6 +35,8 @@ namespace WebCompilerTest.Config
             var newConfig = new WebCompiler.Config();
             const string newInputFileName = "newInputFile";
             newConfig.InputFile = newInputFileName;
+            const string newOutputFileName = "newOutputFile";
+            newConfig.OutputFile = newOutputFileName;
 
             _handler.AddConfig(processingConfigFile, newConfig);
 

--- a/src/WebCompilerVsix/JSON/compilerconfig-schema.json
+++ b/src/WebCompilerVsix/JSON/compilerconfig-schema.json
@@ -87,24 +87,24 @@
     },
 
     "config": {
-      "required": [ "outputFile", "inputFile" ],
-
-      "properties": {
+        "properties": {
         "includeInProject": {
           "description": "Set to true to include the output file in the project. Doesn't work in some Visual Studio project types like ASP.NET 5 applications.",
           "type": "boolean",
           "default": true
         },
+        "inputFiles": { "type": "string" },
         "inputFile": {
-          "description": "One or more relative file names to bundle.",
-          "type": "string",
-          "format": "compiler_relativepath"
+            "description": "One or more relative file names to bundle.",
+            "type": "string",
+            "format": "compiler_relativepath"
         },
         "minify": {
-          "description": "Specify options for minification of the output file.",
-          "type": "object",
-          "allOf": [ { "$ref": "compilerdefaults-schema.json#/definitions/baseMinify" } ]
+            "description": "Specify options for minification of the output file.",
+            "type": "object",
+            "allOf": [ { "$ref": "compilerdefaults-schema.json#/definitions/baseMinify" } ]
         },
+        "outputFiles": { "type": "string" },
         "outputFile": {
           "description": "The relative path to the desired output file name.",
           "type": "string",


### PR DESCRIPTION
Hi,

The earlier Web Essentials had the option to compile multiple files in one action. I really miss being able to compile all less files without having to manage each file separately (including additions / deletions).
I had an idea how something similar might be implemented in the current version. Please check if you find this implementation (or any parts of it) useful. This is also related to #49 .

Thanks,
Zsolt