### PR TITLE
Cleanup gzip files in msbuild task

### DIFF
--- a/src/WebCompiler/Config/ConfigFileProcessor.cs
+++ b/src/WebCompiler/Config/ConfigFileProcessor.cs
@@ -67,10 +67,12 @@ namespace WebCompiler
                 var outputFile = item.GetAbsoluteOutputFile().FullName;
                 var minFile = Path.ChangeExtension(outputFile, ".min" + Path.GetExtension(outputFile));
                 var mapFile = minFile + ".map";
+                var gzipFile = minFile + ".gz";
 
                 if (File.Exists(outputFile)) File.Delete(outputFile);
                 if (File.Exists(minFile)) File.Delete(minFile);
                 if (File.Exists(mapFile)) File.Delete(mapFile);
+                if (File.Exists(gzipFile)) File.Delete(gzipFile);
             }
         }
 


### PR DESCRIPTION
Look to see if the minified gzip file exists and deletes if it does. Resolves #151.