### PR TITLE
Fixed #175: less changes using imports without extensions didn't work

### DIFF
--- a/src/WebCompiler/Dependencies/DependencyResolverBase.cs
+++ b/src/WebCompiler/Dependencies/DependencyResolverBase.cs
@@ -33,6 +33,14 @@ namespace WebCompiler
         }
 
         /// <summary>
+        /// The file extension of files of this type
+        /// </summary>
+        public abstract string FileExtension
+        {
+            get;
+        }
+
+        /// <summary>
         /// Gets the dependency tree
         /// </summary>
         /// <returns></returns>

--- a/src/WebCompiler/Dependencies/LessDependencyResolver.cs
+++ b/src/WebCompiler/Dependencies/LessDependencyResolver.cs
@@ -15,5 +15,13 @@ namespace WebCompiler
                 return new string[] { "*.less" };
             }
         }
+
+        public override string FileExtension
+        {
+            get
+            {
+                return ".less";
+            }
+        }
     }
 }

--- a/src/WebCompiler/Dependencies/SassDependencyResolver.cs
+++ b/src/WebCompiler/Dependencies/SassDependencyResolver.cs
@@ -18,6 +18,14 @@ namespace WebCompiler
             }
         }
 
+        public override string FileExtension
+        {
+            get
+            {
+                return ".scss";
+            }
+        }
+
         /// <summary>
         /// Updates the dependencies of a single file
         /// </summary>
@@ -36,7 +44,7 @@ namespace WebCompiler
                 //remove the dependentfile registration of this file for all other files
                 foreach (var dependenciesPath in this.Dependencies.Keys)
                 {
-                    var lowerDependenciesPath = path.ToLowerInvariant();
+                    var lowerDependenciesPath = dependenciesPath.ToLowerInvariant();
                     if (this.Dependencies[lowerDependenciesPath].DependentFiles.Contains(path))
                     {
                         this.Dependencies[lowerDependenciesPath].DependentFiles.Remove(path);
@@ -51,6 +59,12 @@ namespace WebCompiler
                 foreach (System.Text.RegularExpressions.Match match in matches)
                 {
                     FileInfo importedfile = new FileInfo(System.IO.Path.Combine(info.DirectoryName, match.Groups[3].Value));
+                    //if the file doesn't end with the correct extension, an import statement without extension is probably used, to re-add the extension (#175)
+                    if(String.Compare(importedfile.Extension,this.FileExtension,true) != 0)
+                    {
+                        importedfile = new FileInfo(importedfile.FullName + this.FileExtension);
+                    }
+
                     var dependencyFilePath = importedfile.FullName.ToLowerInvariant();
 
                     if (!this.Dependencies[path].DependentOn.Contains(dependencyFilePath))


### PR DESCRIPTION
The problem was that apparently in less, it is not required to include the ".less" extension in the import statements. This caused the dependent files not to be compiled.

Furthermore i discovered and fixed a sloppy error in which the wrong variable was used in a for loop, that avoided old dependencies to be removed from the dependency tree when a file's dependencies have changed.