### PR TITLE
Added support for basic glob patterns in "inputFile"

### DIFF
--- a/src/WebCompiler/Config/Config.cs
+++ b/src/WebCompiler/Config/Config.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using Newtonsoft.Json;
+using WebCompiler.Helpers;
 
 namespace WebCompiler
 {
@@ -145,6 +147,28 @@ namespace WebCompiler
                 if (!valueComparer.Equals(kvp.Value, secondValue)) return false;
             }
             return true;
+        }
+
+        internal Config Match(string folder, string sourceFile)
+        {
+            string inputFile = Path.Combine(folder, this.InputFile.Replace("/", "\\"));
+            if (GlobHelper.Glob(sourceFile, inputFile))
+            {
+                string compileExtension = CompileHelper.GetCompiledExtension(sourceFile);
+                return new Config()
+                {
+                    InputFile = sourceFile,
+                    OutputFile = Path.ChangeExtension(sourceFile, compileExtension),
+                    FileName = this.FileName,
+                    IncludeInProject = this.IncludeInProject,
+                    Minify = this.Minify,
+                    Options = this.Options,
+                    Output = this.Output,
+                    SourceMap = this.SourceMap
+                };
+            }
+
+            return null;
         }
     }
 }

--- a/src/WebCompiler/Helpers/CompileHelper.cs
+++ b/src/WebCompiler/Helpers/CompileHelper.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WebCompiler.Helpers
+{
+    public static class CompileHelper
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="filename"></param>
+        /// <returns></returns>
+        public static string GetCompiledExtension(string filename)
+        {
+            string extension = Path.GetExtension(filename).ToLowerInvariant();
+            switch (extension)
+            {
+                case ".coffee":
+                case ".iced":
+                case ".litcoffee":
+                case ".jsx":
+                case ".es6":
+                    return ".js";
+
+                case ".js":
+                    return ".es5.js";
+
+                default:
+                    return ".css";
+            }
+        }
+    }
+}

--- a/src/WebCompiler/Helpers/GlobHelper.cs
+++ b/src/WebCompiler/Helpers/GlobHelper.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WebCompiler.Helpers
+{
+    /// <summary>
+    /// Utils for glob matching
+    /// </summary>
+    public static class GlobHelper
+    {
+        /// <summary>
+        /// Returns true if the input text contains a basic glob character: *?
+        /// </summary>
+        /// <param name="text"></param>
+        /// <returns></returns>
+        public static bool IsGlobPattern(string text)
+        {
+            return text != null && text.LastIndexOfAny(new char[] { '*', '?' }) >= 0;
+        }
+
+        /// <summary>
+        /// String matching including basic glob patterns: *?
+        /// </summary>
+        /// <param name="text">string to be matched</param>
+        /// <param name="pattern">pattern to match against</param>
+        /// <returns></returns>
+        public static bool Glob(this string text, string pattern)
+        {
+            int pos = 0;
+
+            while (pattern.Length != pos)
+            {
+                switch (pattern[pos])
+                {
+                    case '?':
+                        break;
+
+                    case '*':
+                        for (int i = text.Length; i >= pos; i--)
+                        {
+                            if (GlobHelper.Glob(text.Substring(i), pattern.Substring(pos + 1)))
+                            {
+                                return true;
+                            }
+                        }
+                        return false;
+
+                    default:
+                        if (text.Length == pos || char.ToUpper(pattern[pos]) != char.ToUpper(text[pos]))
+                        {
+                            return false;
+                        }
+                        break;
+                }
+
+                pos++;
+            }
+
+            return text.Length == pos;
+        }
+    }
+}

--- a/src/WebCompiler/WebCompiler.csproj
+++ b/src/WebCompiler/WebCompiler.csproj
@@ -87,7 +87,9 @@
     <Compile Include="Dependencies\DependencyResolverBase.cs" />
     <Compile Include="Dependencies\LessDependencyResolver.cs" />
     <Compile Include="Dependencies\SassDependencyResolver.cs" />
+    <Compile Include="Helpers\CompileHelper.cs" />
     <Compile Include="Helpers\FileHelpers.cs" />
+    <Compile Include="Helpers\GlobHelper.cs" />
     <Compile Include="Minify\BaseMinifyOptions.cs" />
     <Compile Include="Minify\FileMinifier.cs" />
     <Compile Include="Minify\CssOptions.cs" />

--- a/src/WebCompilerVsix/Adornments/AdornmentProvider.cs
+++ b/src/WebCompilerVsix/Adornments/AdornmentProvider.cs
@@ -9,6 +9,7 @@ using Microsoft.VisualStudio.Shell.Settings;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Utilities;
+using WebCompiler.Helpers;
 
 namespace WebCompilerVsix
 {
@@ -101,6 +102,11 @@ namespace WebCompilerVsix
 
                     foreach (Config config in configs)
                     {
+                        if (GlobHelper.IsGlobPattern(config.InputFile))
+                        {
+                            continue;
+                        }
+
                         if (config.GetAbsoluteOutputFile().FullName.Equals(normalizedFilePath, StringComparison.OrdinalIgnoreCase))
                         {
                             GeneratedAdornment generated = new GeneratedAdornment(textView, _isVisible, _initOpacity);

--- a/src/WebCompilerVsix/Commands/CreateConfig.cs
+++ b/src/WebCompilerVsix/Commands/CreateConfig.cs
@@ -7,6 +7,7 @@ using EnvDTE;
 using EnvDTE80;
 using Microsoft.VisualStudio.Shell;
 using WebCompiler;
+using WebCompiler.Helpers;
 
 namespace WebCompilerVsix
 {
@@ -166,16 +167,8 @@ namespace WebCompilerVsix
 
         private static string GetOutputFileName(string inputFile)
         {
-            string extension = Path.GetExtension(inputFile).ToLowerInvariant();
-            string ext = ".css";
-
-            if (extension == ".coffee" || extension == ".iced" || extension == ".litcoffee" || extension == ".jsx" || extension == ".es6")
-                ext = ".js";
-
-            if (extension == ".js")
-                ext = ".es5.js";
-
-            return Path.ChangeExtension(inputFile, ext);
+            string extension = CompileHelper.GetCompiledExtension(inputFile);
+            return Path.ChangeExtension(inputFile, extension);
         }
     }
 }

--- a/src/WebCompilerVsix/JSON/RelativeFilePathFormatProvider.cs
+++ b/src/WebCompilerVsix/JSON/RelativeFilePathFormatProvider.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.Composition;
 using System.IO;
 using Microsoft.JSON.Core.Parser.TreeItems;
 using Microsoft.JSON.Core.Schema;
+using WebCompiler.Helpers;
 
 namespace WebCompilerVsix.JSON
 {
@@ -33,7 +34,7 @@ namespace WebCompilerVsix.JSON
             string folder = Path.GetDirectoryName(doc.DocumentLocation);
             string absolutePath = Path.Combine(folder, canonicalizedValue);
 
-            if (!File.Exists(absolutePath) && !Directory.Exists(absolutePath))
+            if (!File.Exists(absolutePath) && !Directory.Exists(absolutePath) && !GlobHelper.IsGlobPattern(absolutePath))
                 yield return $"The file '{canonicalizedValue}' does not exist";
         }
     }

--- a/src/WebCompilerVsix/source.extension.vsixmanifest
+++ b/src/WebCompilerVsix/source.extension.vsixmanifest
@@ -1,26 +1,26 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-    <Metadata>
-        <Identity Id="148ffa77-d70a-407f-892b-9ee542346862" Version="1.10" Language="en-US" Publisher="Mads Kristensen" />
-        <DisplayName>Web Compiler</DisplayName>
-        <Description xml:space="preserve">The easiest and most powerful way to compile LESS, Scss, Stylus, JSX and CoffeeScript files directly within Visual Studio or through MSBuild.</Description>
-        <MoreInfo>https://github.com/madskristensen/WebCompiler</MoreInfo>
-        <License>Resources\LICENSE</License>
-        <ReleaseNotes>https://github.com/madskristensen/WebCompiler/blob/master/CHANGELOG.md</ReleaseNotes>
-        <Icon>Resources\icon.png</Icon>
-        <PreviewImage>Resources\preview.png</PreviewImage>
-        <Tags>Compile, LESS, Sass, Scss, CoffeeScript, JavaScript, JSX, ES6, Stylus</Tags>
-    </Metadata>
-    <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0]" />
-    </Installation>
-    <Dependencies>
-        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-        <Dependency Id="Microsoft.VisualStudio.MPF.14.0" DisplayName="Visual Studio MPF 14.0" d:Source="Installed" Version="[14.0]" />
-    </Dependencies>
-    <Assets>
-        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-        <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
-        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="File" Path="registry.pkgdef" />
-    </Assets>
+  <Metadata>
+    <Identity Id="148ffa77-d70a-407f-892b-9ee542346862" Version="1.11.1" Language="en-US" Publisher="Mads Kristensen" />
+    <DisplayName>Web Compiler</DisplayName>
+    <Description xml:space="preserve">The easiest and most powerful way to compile LESS, Scss, Stylus, JSX and CoffeeScript files directly within Visual Studio or through MSBuild.</Description>
+    <MoreInfo>https://github.com/madskristensen/WebCompiler</MoreInfo>
+    <License>Resources\LICENSE</License>
+    <ReleaseNotes>https://github.com/madskristensen/WebCompiler/blob/master/CHANGELOG.md</ReleaseNotes>
+    <Icon>Resources\icon.png</Icon>
+    <PreviewImage>Resources\preview.png</PreviewImage>
+    <Tags>Compile, LESS, Sass, Scss, CoffeeScript, JavaScript, JSX, ES6, Stylus</Tags>
+  </Metadata>
+  <Installation>
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0]" />
+  </Installation>
+  <Dependencies>
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+    <Dependency Id="Microsoft.VisualStudio.MPF.14.0" DisplayName="Visual Studio MPF 14.0" d:Source="Installed" Version="[14.0]" />
+  </Dependencies>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
+    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="File" Path="registry.pkgdef" />
+  </Assets>
 </PackageManifest>


### PR DESCRIPTION
This allows the "inputFile" attribute of each config to include the glob
characters: *?

Any file which matches the glob pattern will be compiled.  The
"outputFile" attribute is ignored and instead the sourceFile's path is
used as the output file, but with the extension changed to the compiled
extension.  e.g. less --> css

Saving the compilerconfig.json currently does not compile all matching
files in the project.
