### PR TITLE
Added support for reading lineFeed style option (cr | crlf | lf | lfcr)

### DIFF
--- a/src/WebCompiler/Compile/SassCompiler.cs
+++ b/src/WebCompiler/Compile/SassCompiler.cs
@@ -134,6 +134,9 @@ namespace WebCompiler
             if (!string.IsNullOrEmpty(options.SourceMapRoot))
                 arguments += " --source-map-root=" + options.SourceMapRoot;
 
+            if (!string.IsNullOrEmpty(options.LineFeed))
+                arguments += " --linefeed=" + options.LineFeed;
+
             return arguments;
         }
     }

--- a/src/WebCompiler/Compile/SassOptions.cs
+++ b/src/WebCompiler/Compile/SassOptions.cs
@@ -97,5 +97,13 @@ namespace WebCompiler
         /// </summary>
         [JsonProperty("sourceMapRoot")]
         public string SourceMapRoot { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Linefeed style (cr | crlf | lf | lfcr)
+        /// </summary>
+        [JsonProperty("lineFeed")]
+        public string LineFeed { get; set; } = string.Empty;
+
+
     }
 }


### PR DESCRIPTION
This change adds support for the `--linefeed` option documented in the [node-sass project](https://github.com/sass/node-sass#command-line-interface).  This issue was reported as [#136](https://github.com/madskristensen/WebCompiler/issues/136) on the issue tracker.
