### PR TITLE
Fix for #284. Dependencies for @import inside other rules.

### DIFF
--- a/src/WebCompiler/Dependencies/SassDependencyResolver.cs
+++ b/src/WebCompiler/Dependencies/SassDependencyResolver.cs
@@ -50,7 +50,7 @@ namespace WebCompiler
                 string content = File.ReadAllText(info.FullName);
 
                 //match both <@import "myFile.scss";> and <@import url("myFile.scss");> syntax
-                var matches = Regex.Matches(content, @"(?<=^@import(?:[\s]+))(?:(?:\(\w+\)))?\s*(?:url)?(?<url>[^;]+)", RegexOptions.Multiline);
+                var matches = Regex.Matches(content, @"(?<=@import(?:[\s]+))(?:(?:\(\w+\)))?\s*(?:url)?(?<url>[^;]+)", RegexOptions.Multiline);
                 foreach (Match match in matches)
                 {
                     var importedfiles = GetFileInfos(info, match);


### PR DESCRIPTION
Fix for #284. Correctly figure out less and scss dependencies when @import directive is inside other rules like @media. 

Example:
@import "CssModules/app-responsive-constants.less";

@media screen and (max-width: 767px) {
    @import "CssModules/app-xs-only-module.less";
}

