### PR TITLE
Fix dependency relative/absolute path mismatch issues

### DIFF
--- a/src/WebCompiler/Dependencies/SassDependencyResolver.cs
+++ b/src/WebCompiler/Dependencies/SassDependencyResolver.cs
@@ -29,7 +29,8 @@ namespace WebCompiler
         {
             if (this.Dependencies != null)
             {
-                path = path.ToLowerInvariant();
+                FileInfo info = new FileInfo(path);
+                path = info.FullName.ToLowerInvariant();
 
                 if (!Dependencies.ContainsKey(path))
                     Dependencies[path] = new Dependencies();
@@ -46,7 +47,6 @@ namespace WebCompiler
                     }
                 }
 
-                FileInfo info = new FileInfo(path);
                 string content = File.ReadAllText(info.FullName);
 
                 //match both <@import "myFile.scss";> and <@import url("myFile.scss");> syntax


### PR DESCRIPTION
The source file path was relative while imports would use absolute paths which resulted in nested imports not being linked correctly with the source file - i.e. not recompiling on save.

### Example
```scss
// 1. styles.scss
@import "navigation/all";


// 2. navigation/_all.scss
.navigation {
    @import "list";
}


// 3. navigation/_list.scss
&__list {
    // ...
}
```

Saving `navigation/_list.scss` would not recompile `styles.scss`.