### PR TITLE
Force recompilation for "recompile-all" menu command

### DIFF
--- a/src/WebCompilerVsix/Commands/CompileAllFiles.cs
+++ b/src/WebCompilerVsix/Commands/CompileAllFiles.cs
@@ -63,7 +63,7 @@ namespace WebCompilerVsix.Commands
                 foreach (string config in configs)
                 {
                     if (!string.IsNullOrEmpty(config))
-                        CompilerService.Process(config);
+                        CompilerService.Process(config, force: true);
                 }
             }
         }


### PR DESCRIPTION
Without `force` set to `true` the **Re-compile all files in solution** menu command in the **Build** menu wont do anything if the last write time of the output file is  newer than the source file.