### PR TITLE
Fix stylus files not being compiled on save

### DIFF
--- a/src/WebCompilerVsix/ContentType/StylContentTypeDefinition.cs
+++ b/src/WebCompilerVsix/ContentType/StylContentTypeDefinition.cs
@@ -1,0 +1,23 @@
+﻿using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Utilities;
+
+namespace WebCompilerVsix
+{
+    public class StylContentTypeDefinition
+    {
+        public const string StylContentType = "Stylus";
+
+        /// <summary>
+        /// Exports the Stylus content type
+        /// </summary>
+        [Export(typeof(ContentTypeDefinition))]
+        [Name(StylContentType)]
+        [BaseDefinition("code")]
+        public ContentTypeDefinition IStylusContentType { get; set; }
+
+        [Export(typeof(FileExtensionToContentTypeDefinition))]
+        [ContentType(StylContentType)]
+        [FileExtension(".styl")]
+        public FileExtensionToContentTypeDefinition StylusFileExtension { get; set; }
+    }
+}

--- a/src/WebCompilerVsix/ContentType/StylusContentTypeDefinition.cs
+++ b/src/WebCompilerVsix/ContentType/StylusContentTypeDefinition.cs
@@ -1,0 +1,23 @@
+﻿using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Utilities;
+
+namespace WebCompilerVsix
+{
+    public class StylusContentTypeDefinition
+    {
+        public const string StylusContentType = "Stylus";
+
+        /// <summary>
+        /// Exports the Stylus content type
+        /// </summary>
+        [Export(typeof(ContentTypeDefinition))]
+        [Name(StylusContentType)]
+        [BaseDefinition("code")]
+        public ContentTypeDefinition IStylusContentType { get; set; }
+
+        [Export(typeof(FileExtensionToContentTypeDefinition))]
+        [ContentType(StylusContentType)]
+        [FileExtension(".stylus")]
+        public FileExtensionToContentTypeDefinition StylusFileExtension { get; set; }
+    }
+}

--- a/src/WebCompilerVsix/FileListeners/SourceFileCreationListener.cs
+++ b/src/WebCompilerVsix/FileListeners/SourceFileCreationListener.cs
@@ -20,6 +20,8 @@ namespace WebCompilerVsix.Listeners
     [ContentType(SassContentTypeDefinition.SassContentType)]
     [ContentType(HandlebarsContentTypeDefinition.HandleBarsContentType)]
     [ContentType(HBSContentTypeDefinition.HBSContentType)]
+    [ContentType(StylusContentTypeDefinition.StylusContentType)]
+    [ContentType(StylContentTypeDefinition.StylContentType)]
     [TextViewRole(PredefinedTextViewRoles.Document)]
     class SourceFileCreationListener : IVsTextViewCreationListener
     {

--- a/src/WebCompilerVsix/WebCompilerVsix.csproj
+++ b/src/WebCompilerVsix/WebCompilerVsix.csproj
@@ -64,6 +64,8 @@
     <Compile Include="ContentType\HBSContentTypeDefinition.cs" />
     <Compile Include="ContentType\HandlebarsContentTypeDefinition.cs" />
     <Compile Include="ContentType\SassContentTypeDefinition.cs" />
+    <Compile Include="ContentType\StylContentTypeDefinition.cs" />
+    <Compile Include="ContentType\StylusContentTypeDefinition.cs" />
     <Compile Include="ErrorList\ErrorListService.cs" />
     <Compile Include="ErrorList\SinkManager.cs" />
     <Compile Include="ErrorList\TableDataSource.cs" />


### PR DESCRIPTION
`.styl` and `.stylus` files were not being caught by `SourceFileCreationListener` because it was missing those content type attributes resulting in stylus files not being compiled on save.