### PR TITLE
Add ability to configure working directory for unzipping/running node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ _NCrunch_WebCompiler#Node
 
 #Node
 src/WebCompiler/Node/node_modules/*
+src/WebCompiler/Node/node.exe

--- a/src/WebCompiler/Compile/CompilerService.cs
+++ b/src/WebCompiler/Compile/CompilerService.cs
@@ -11,11 +11,18 @@ namespace WebCompiler
     public static class CompilerService
     {
         internal const string Version = "1.4.167";
-        private static readonly string _path = Path.Combine(Path.GetTempPath(), "WebCompiler" + Version);
+        internal const string WorkingDirectoryEnvVarName = "WEBCOMPILER_WORKING_DIRECTORY";
+        private static readonly string _path = GetWorkingDirectoryPath();
         private static object _syncRoot = new object(); // Used to lock on the initialize step
 
         /// <summary>A list of allowed file extensions.</summary>
         public static readonly string[] AllowedExtensions = new[] { ".LESS", ".SCSS", ".SASS", ".STYL", ".COFFEE", ".ICED", ".JS", ".JSX", ".ES6", ".HBS", ".HANDLEBARS" };
+
+        internal static string GetWorkingDirectoryPath()
+        {
+            var envValue = Environment.GetEnvironmentVariable(WorkingDirectoryEnvVarName);
+            return Path.Combine(envValue ?? Path.GetTempPath(), "WebCompiler" + Version);
+        }
 
         /// <summary>
         /// Test if a file type is supported by the compilers.


### PR DESCRIPTION
This has fixed intermittent issues that are similar to #272 on our TeamCity CI server.  By allowing us to configure the location we use to unzip the node.exe and node_modules directory we can verify that our build agents have the appropriate permissions and that files are not being cleaned or locked during builds.

To do this, we added support for an environment variable "WEBCOMPILER_WORKING_DIRECTORY" in
CompilerService.  If set, we will unzip node.exe and node modules into a subdirectory of this directory instead of into the system temp directory.

This is intended for CI or build server environments where temp directories are often cleaned after every run, or are set per-build-agent.

