### PR TITLE
Implement SASS LineFeed parameter in Config

### DIFF
--- a/src/WebCompiler/Compile/SassOptions.cs
+++ b/src/WebCompiler/Compile/SassOptions.cs
@@ -49,6 +49,10 @@ namespace WebCompiler
             var sourceMapRoot = GetValue(config, "sourceMapRoot");
             if (sourceMapRoot != null)
                 SourceMapRoot = sourceMapRoot;
+
+            var lineFeed = GetValue(config, "lineFeed");
+            if (lineFeed != null)
+                LineFeed = lineFeed;
         }
 
         /// <summary>


### PR DESCRIPTION
Allow a config setting to apply a value to the SASS Compiler LineFeed configuration option.