### PR TITLE
Add TypeScript ContentType to `SourceFileCreationListener.cs`

### DIFF
--- a/src/WebCompilerVsix/FileListeners/SourceFileCreationListener.cs
+++ b/src/WebCompilerVsix/FileListeners/SourceFileCreationListener.cs
@@ -17,6 +17,7 @@ namespace WebCompilerVsix.Listeners
     [ContentType("Iced")]
     [ContentType("jsx")]
     [ContentType("javascript")]
+    [ContentType("TypeScript")]
     [ContentType(SassContentTypeDefinition.SassContentType)]
     [ContentType(HandlebarsContentTypeDefinition.HandleBarsContentType)]
     [ContentType(HBSContentTypeDefinition.HBSContentType)]


### PR DESCRIPTION
Add TypeScript ContentType to `SourceFileCreationListener.cs` in order to fix issue where jsx and js files were not auto re-compiling [as detailed in issue 299](https://github.com/madskristensen/WebCompiler/issues/299).