### PR TITLE
Keep track of which Less dependencies have been checked.

### DIFF
--- a/src/WebCompiler/Config/Config.cs
+++ b/src/WebCompiler/Config/Config.cs
@@ -105,13 +105,21 @@ namespace WebCompiler
             return false;
         }
 
-        private bool CheckForNewerDependenciesRecursively(string key, Dictionary<string, Dependencies> dependencies, FileInfo output)
+        private bool CheckForNewerDependenciesRecursively(string key, Dictionary<string, Dependencies> dependencies, FileInfo output, HashSet<string> checkedDependencies = null)
         {
+            if (checkedDependencies == null)
+                checkedDependencies = new HashSet<string>();
+
+            checkedDependencies.Add(key);
+
             if (!dependencies.ContainsKey(key))
                 return false;
 
             foreach (var file in dependencies[key].DependentOn.ToArray())
             {
+                if (checkedDependencies.Contains(file))
+                    continue;
+
                 var fileInfo = new FileInfo(file);
 
                 if (!fileInfo.Exists)
@@ -120,7 +128,7 @@ namespace WebCompiler
                 if (fileInfo.LastWriteTimeUtc > output.LastWriteTimeUtc)
                     return true;
 
-                if (CheckForNewerDependenciesRecursively(file, dependencies, output))
+                if (CheckForNewerDependenciesRecursively(file, dependencies, output, checkedDependencies))
                     return true;
             }
 

--- a/src/WebCompilerTest/Compile/LessTest.cs
+++ b/src/WebCompilerTest/Compile/LessTest.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using WebCompiler;
@@ -25,6 +26,8 @@ namespace WebCompilerTest
             File.Delete("../../artifacts/less/error.css");
             File.Delete("../../artifacts/less/relative.css");
             File.Delete("../../artifacts/less/relative.min.css");
+            File.Delete("../../artifacts/less/circrefa.css");
+            File.Delete("../../artifacts/less/circrefa.min.css");
         }
 
         [TestMethod, TestCategory("LESS")]
@@ -83,6 +86,20 @@ namespace WebCompilerTest
         public void OtherExtensionTypeSourceFileChangedTest()
         {
             var result = _processor.SourceFileChanged("../../artifacts/lessconfig.json", "scss/test.scss", null);
+            Assert.AreEqual(0, result.Count<CompilerResult>());
+        }
+
+        [TestMethod, TestCategory("LESS")]
+        public void CompileCircularReference()
+        {
+            // Set the last write time and create outputs in a way that Config.CheckForNewerDependenciesRecursively will be called
+            File.SetLastWriteTimeUtc("../../artifacts/less/circrefa.less", DateTime.UtcNow);
+            File.SetLastWriteTimeUtc("../../artifacts/less/circrefb.less", DateTime.UtcNow);
+            File.Create("../../artifacts/less/circrefa.css");
+            File.Create("../../artifacts/less/circrefa.min.css");
+
+            // Since the outputs were generated after the inputs, no compilation should have occurred
+            var result = _processor.Process("../../artifacts/lessconfigCircRef.json");
             Assert.AreEqual(0, result.Count<CompilerResult>());
         }
     }

--- a/src/WebCompilerTest/Compile/LessTest.cs
+++ b/src/WebCompilerTest/Compile/LessTest.cs
@@ -95,8 +95,8 @@ namespace WebCompilerTest
             // Set the last write time and create outputs in a way that Config.CheckForNewerDependenciesRecursively will be called
             File.SetLastWriteTimeUtc("../../artifacts/less/circrefa.less", DateTime.UtcNow);
             File.SetLastWriteTimeUtc("../../artifacts/less/circrefb.less", DateTime.UtcNow);
-            File.Create("../../artifacts/less/circrefa.css");
-            File.Create("../../artifacts/less/circrefa.min.css");
+            File.WriteAllText("../../artifacts/less/circrefa.css", string.Empty);
+            File.WriteAllText("../../artifacts/less/circrefa.min.css", string.Empty);
 
             // Since the outputs were generated after the inputs, no compilation should have occurred
             var result = _processor.Process("../../artifacts/lessconfigCircRef.json");

--- a/src/WebCompilerTest/WebCompilerTest.csproj
+++ b/src/WebCompilerTest/WebCompilerTest.csproj
@@ -86,6 +86,9 @@
     <None Include="artifacts\handlebars\test.hbs" />
     <None Include="artifacts\handlebars\error.hbs" />
     <None Include="artifacts\handlebars\_partial.hbs" />
+    <None Include="artifacts\lessconfigCircRef.json" />
+    <None Include="artifacts\less\circrefa.less" />
+    <None Include="artifacts\less\circrefb.less" />
     <None Include="artifacts\scss\sub\foo.scss" />
     <None Include="artifacts\stylusconfig.json" />
     <None Include="artifacts\less\sub\relative.less" />

--- a/src/WebCompilerTest/artifacts/less/circrefa.less
+++ b/src/WebCompilerTest/artifacts/less/circrefa.less
@@ -1,0 +1,3 @@
+﻿@import "circrefb.less";
+
+@primary-color: #f00;

--- a/src/WebCompilerTest/artifacts/less/circrefb.less
+++ b/src/WebCompilerTest/artifacts/less/circrefb.less
@@ -1,0 +1,5 @@
+﻿@import (reference) "circrefa.less";
+
+.btn {
+    background-color: @primary-color;
+}

--- a/src/WebCompilerTest/artifacts/lessconfigCircRef.json
+++ b/src/WebCompilerTest/artifacts/lessconfigCircRef.json
@@ -1,0 +1,10 @@
+﻿[
+  {
+    "outputFile": "less/circrefa.css",
+    "inputFile": "less/circrefa.less",
+    "includeInProject": true,
+    "options": {
+      "relativeUrls": true
+    }
+  }
+]


### PR DESCRIPTION
bool CheckForNewerDependenciesRecursively(string key, Dictionary<string, Dependencies> dependencies, FileInfo output) is the function causing the stack overflow. When you save all of the files, the input files have a newer timestamp than the outputs so bool CompilationRequired() never calls the check for dependencies.

The issue happens when you have circular reference in your less. For example:

``` less
// main.less
@import "buttons.less";

@primary-color: #f00;
```
``` less
// buttons.less
@import (reference) "main.less";

.btn {
  background-color: @primary-color;
}
```

This is valid Less which the compiler handles just fine but WebCompiler.exe does not keep track of dependencies already checked so it never exits. I will work on a pull request.

This fixes #387, #347