### PR TITLE
Update strict math

### DIFF
--- a/src/WebCompiler/Compile/LessCompiler.cs
+++ b/src/WebCompiler/Compile/LessCompiler.cs
@@ -116,7 +116,7 @@ namespace WebCompiler
                 arguments += " --source-map-map-inline";
 
             if (options.StrictMath)
-                arguments += " --strict-math=on";
+                arguments += " --math=strict";
 
             if (options.IECompat)
                 arguments += " --ie-compat";

--- a/src/WebCompiler/Compile/LessCompiler.cs
+++ b/src/WebCompiler/Compile/LessCompiler.cs
@@ -115,8 +115,10 @@ namespace WebCompiler
             if (options.SourceMap || config.SourceMap)
                 arguments += " --source-map-map-inline";
 
-            if (options.StrictMath)
-                arguments += " --math=strict";
+            if (options.Math != null)
+                arguments += $" --math={options.Math}";
+            else if (options.StrictMath)
+                arguments += " --math=strict-legacy";
 
             if (options.IECompat)
                 arguments += " --ie-compat";

--- a/src/WebCompiler/Compile/LessOptions.cs
+++ b/src/WebCompiler/Compile/LessOptions.cs
@@ -32,6 +32,10 @@ namespace WebCompiler
             if (ieCompat != null)
                 IECompat = ieCompat.ToLowerInvariant() == trueStr;
 
+            var math = GetValue(config, "math");
+            if (math != null)
+                Math = math;
+
             var strictMath = GetValue(config, "strictMath");
             if (strictMath != null)
                 StrictMath = strictMath.ToLowerInvariant() == trueStr;
@@ -84,6 +88,12 @@ namespace WebCompiler
         /// </summary>
         [JsonProperty("ieCompat")]
         public bool IECompat { get; set; } = true;
+
+        /// <summary>
+        /// New option for math that replaces 'strictMath' option.
+        /// </summary>
+        [JsonProperty("math")]
+        public string Math { get; set; } = null;
 
         /// <summary>
         /// Without this option on Less will try and process all maths in your CSS.

--- a/src/WebCompilerTest/Compile/LessOptionsTest.cs
+++ b/src/WebCompilerTest/Compile/LessOptionsTest.cs
@@ -28,7 +28,7 @@ namespace WebCompilerTest
         {
             var configs = ConfigHandler.GetConfigs("../../artifacts/lessconfig.json");
             var result = LessOptions.FromConfig(configs.First());
-            Assert.AreEqual(true, result.StrictMath);
+            Assert.AreEqual("strict", result.Math);
         }
     }
 }

--- a/src/WebCompilerTest/Compile/LessTest.cs
+++ b/src/WebCompilerTest/Compile/LessTest.cs
@@ -31,6 +31,7 @@ namespace WebCompilerTest
         public void CompileLess()
         {
             var result = _processor.Process("../../artifacts/lessconfig.json");
+            Assert.IsTrue(result.All(r => !r.HasErrors));
             Assert.IsTrue(File.Exists("../../artifacts/less/test.css"));
             Assert.IsTrue(File.Exists("../../artifacts/less/test.min.css"));
             Assert.IsTrue(result.ElementAt(1).CompiledContent.Contains("url(foo.png)"));
@@ -51,6 +52,7 @@ namespace WebCompilerTest
         public void CompileLessWithError()
         {
             var result = _processor.Process("../../artifacts/lessconfigerror.json");
+            Assert.IsTrue(result.Any(r => r.HasErrors));
             Assert.IsTrue(result.Count() == 1);
             Assert.IsTrue(result.ElementAt(0).HasErrors);
         }
@@ -59,6 +61,7 @@ namespace WebCompilerTest
         public void CompileLessWithParsingExceptionError()
         {
             var result = _processor.Process("../../artifacts/lessconfigParseerror.json");
+            Assert.IsTrue(result.Any(r => r.HasErrors));
             Assert.IsTrue(result.Count() == 1);
             Assert.IsTrue(result.ElementAt(0).HasErrors);
             Assert.AreNotEqual(0, result.ElementAt(0).Errors.ElementAt(0).LineNumber, "LineNumber is set when engine.TransformToCss generate a ParsingException");
@@ -76,6 +79,7 @@ namespace WebCompilerTest
         public void AssociateExtensionSourceFileChangedTest()
         {
             var result = _processor.SourceFileChanged("../../artifacts/lessconfig.json", "less/test.less", null);
+            Assert.IsTrue(result.All(r => !r.HasErrors));
             Assert.AreEqual(2, result.Count<CompilerResult>());
         }
 
@@ -83,6 +87,7 @@ namespace WebCompilerTest
         public void OtherExtensionTypeSourceFileChangedTest()
         {
             var result = _processor.SourceFileChanged("../../artifacts/lessconfig.json", "scss/test.scss", null);
+            Assert.IsTrue(result.All(r => !r.HasErrors));
             Assert.AreEqual(0, result.Count<CompilerResult>());
         }
     }

--- a/src/WebCompilerTest/Compile/LessTest.cs
+++ b/src/WebCompilerTest/Compile/LessTest.cs
@@ -90,5 +90,12 @@ namespace WebCompilerTest
             Assert.IsTrue(result.All(r => !r.HasErrors));
             Assert.AreEqual(0, result.Count<CompilerResult>());
         }
+
+        [TestMethod, TestCategory("LESS")]
+        public void CompileLessLegacyStrictMath()
+        {
+            var result = _processor.Process("../../artifacts/lessconfigLegacyStrictMath.json");
+            Assert.IsTrue(result.All(r => !r.HasErrors || r.Errors.All(e => e.IsWarning)));
+        }
     }
 }

--- a/src/WebCompilerTest/WebCompilerTest.csproj
+++ b/src/WebCompilerTest/WebCompilerTest.csproj
@@ -86,6 +86,7 @@
     <None Include="artifacts\handlebars\test.hbs" />
     <None Include="artifacts\handlebars\error.hbs" />
     <None Include="artifacts\handlebars\_partial.hbs" />
+    <None Include="artifacts\lessconfigLegacyStrictMath.json" />
     <None Include="artifacts\scss\sub\foo.scss" />
     <None Include="artifacts\stylusconfig.json" />
     <None Include="artifacts\less\sub\relative.less" />

--- a/src/WebCompilerTest/artifacts/lessconfigLegacyStrictMath.json
+++ b/src/WebCompilerTest/artifacts/lessconfigLegacyStrictMath.json
@@ -5,7 +5,7 @@
     "includeInProject": true,
     "options": {
       "relativeUrls": true,
-      "math": "strict"
+      "math": "strict-legacy"
     }
   },
   {

--- a/src/WebCompilerVsix/JSON/compilerdefaults-schema.json
+++ b/src/WebCompilerVsix/JSON/compilerdefaults-schema.json
@@ -33,13 +33,18 @@
           "type": "boolean",
           "default": true
         },
+        "math": {
+          "description": "LESS only. Specifies which mode Less will use to process the math in your CSS.",
+          "default": "none",
+          "enum": ["always", "parens-division", "parens", "strict", "strict-legacy"]
+        },
         "sourceMap": {
           "description": "Generates a base64 encoded source map at the bottom of the output.",
           "type": "boolean",
           "default": false
         },
         "strictMath": {
-          "description": "LESS only. Without this option on Less will try and process all maths in your CSS.",
+          "description": "(DEPRECATED: Use 'math' instead) LESS only. Without this option on Less will try and process all maths in your CSS.",
           "type": "boolean",
           "default": false
         },


### PR DESCRIPTION
Fixes #418

Added a new Less option `math`.  Backwards compatibility is maintained for those already using 'strictMath'.