### PR TITLE
correct relative _WebCompilerTaskAssembly paths

### DIFF
--- a/src/WebCompiler/MSBuild/BuildWebCompiler.targets
+++ b/src/WebCompiler/MSBuild/BuildWebCompiler.targets
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <_WebCompilerTaskAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">..\tools\netstandard2.0\WebCompiler.dll</_WebCompilerTaskAssembly>
-        <_WebCompilerTaskAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">..\tools\net46\WebCompiler.exe</_WebCompilerTaskAssembly>
+        <_WebCompilerTaskAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\netstandard2.0\WebCompiler.dll</_WebCompilerTaskAssembly>
+        <_WebCompilerTaskAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net46\WebCompiler.exe</_WebCompilerTaskAssembly>
     </PropertyGroup>
 
     <UsingTask AssemblyFile="$(_WebCompilerTaskAssembly)" TaskName="WebCompiler.CompilerBuildTask"/>


### PR DESCRIPTION
madskristensen/WebCompiler#351: the _WebCompilerTaskAssembly paths defined in build/BuildWebCompiler.targets are intended to be relative to that file, but may not always be interpreted as such.  using $(MSBuildThisFileDirectory) ensures that they always are.