### PR TITLE
Handlebars fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Web Compiler
 
-A Visual Studio extension that compiles LESS, Sass Stylus, JSX, ES6 and CoffeeScript
+A Visual Studio extension that compiles LESS, Sass Stylus, JSX, ES6, CoffeeScript and Handlebars
 files.
 
 [![Build status](https://ci.appveyor.com/api/projects/status/kyk8vpst641r2n0r?svg=true)](https://ci.appveyor.com/project/madskristensen/webcompiler)
@@ -16,7 +16,7 @@ for changes and roadmap.
 
 ### Features
 
-- Compilation of LESS, Scss, Stylus, JSX, ES6 and (Iced)CoffeeScript files
+- Compilation of LESS, Scss, Stylus, JSX, ES6, (Iced)CoffeeScript and HBS (Handlebars) files
 - Saving a source file triggers re-compilation automatically
 - Specify compiler options for each individual file
 - Error List integration
@@ -31,7 +31,7 @@ for changes and roadmap.
 
 ### Getting started
 
-Right-click any `.less`, `.scss`, `.styl`, `.jsx`, `.es6` or `.coffee` file in Solution Explorer to
+Right-click any `.less`, `.scss`, `.styl`, `.jsx`, `.es6`, `.coffee` or `.hbs` file in Solution Explorer to
 setup compilation.
 
 ![Compile file](art/contextmenu-compile.png)
@@ -46,7 +46,7 @@ run all the configured compilers.
 
 ### Compile on save
 
-Any time a `.less`, `.scss`, `.styl`, `.jsx`, `.es6` or `.coffee` file is modified within
+Any time a `.less`, `.scss`, `.styl`, `.jsx`, `.es6`, `.coffee` or `.hbs` file is modified within
 Visual Studio, the compiler runs automatically to produce the compiled output file.
 
 The same is true when saving the `compilerconfig.json` file where

--- a/src/WebCompiler/Compile/HandlebarsOptions.cs
+++ b/src/WebCompiler/Compile/HandlebarsOptions.cs
@@ -63,7 +63,7 @@ namespace WebCompiler
         /// </summary>
         protected override string CompilerFileName
         {
-            get { return "hbs"; }
+            get { return "handlebars"; }
         }
 
         /// <summary>
@@ -85,7 +85,7 @@ namespace WebCompiler
         public string Name { get; set; } = "";
 
         /// <summary>
-        /// Template namespace 
+        /// Template namespace
         /// </summary>
         [JsonProperty("namespace")]
         public string TemplateNameSpace { get; set; } = "";

--- a/src/WebCompiler/Compile/HandlebarsOptions.cs
+++ b/src/WebCompiler/Compile/HandlebarsOptions.cs
@@ -1,5 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System.Linq;
 
 namespace WebCompiler
 {
@@ -54,8 +53,8 @@ namespace WebCompiler
                 KnownHelpersOnly = knownHelpersOnly.ToLowerInvariant() == trueStr;
 
             var knownHelpers = GetValue(config, "knownHelpers");
-            if (knownHelpers != null)            
-                KnownHelpers = knownHelpers.Split(',').Where(s => !string.IsNullOrWhiteSpace(s)).Select(s => s.Trim()).ToArray();
+            if (knownHelpers != null)
+                KnownHelpers = JsonConvert.DeserializeObject<string[]>(knownHelpers);
         }
 
         /// <summary>

--- a/src/WebCompilerVsix/JSON/compilerdefaults-schema.json
+++ b/src/WebCompilerVsix/JSON/compilerdefaults-schema.json
@@ -157,7 +157,7 @@
         }
       }
     },
-    
+
     "handlebars": {
       "description": "Specify options for the compiler.",
       "type": "object",
@@ -182,8 +182,11 @@
         },
         "knownHelpers": {
           "description": "List of known helpers for a more optimized output (comma separated)",
-          "type": "string",
-          "default": ""
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          }
         },
         "knownHelpersOnly": {
           "description": "Compile with known helpers only",

--- a/src/common.props
+++ b/src/common.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Copyright>Copyright 2017</Copyright>
     <Authors>Mads Kristensen</Authors>
-    <Description>Compiles LESS, Sass, JSX and CoffeeScript files</Description>
+    <Description>Compiles LESS, Sass, JSX, CoffeeScript and Handlebars files</Description>
     <PackageTags>LESS;Sass;Scss;JSX;EcmaScript6;CoffeeScript</PackageTags>
     <PackageIconUrl>https://raw.githubusercontent.com/madskristensen/WebCompiler/master/src/WebCompilerVsix/Resources/icon.png</PackageIconUrl>
     <PackageLicenseUrl>https://github.com/madskristensen/WebCompiler/blob/master/LICENSE</PackageLicenseUrl>


### PR DESCRIPTION
Hey Mads,
Two problems with the handlebars options class fixed.
Unfortunately in the last couple of years, the default config file was always ignored by the compiler. My bad. :)
Also a problem with not parsing the `knownHelpers` correctly fixed.

I also updated the package information and the readme file and added the handlebars to the list of supported file types.